### PR TITLE
flake8 error minimization

### DIFF
--- a/peakinvestigator/__init__.py
+++ b/peakinvestigator/__init__.py
@@ -1,4 +1,4 @@
-## -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2016, Veritomyx, Inc.
 #

--- a/peakinvestigator/actions/__init__.py
+++ b/peakinvestigator/actions/__init__.py
@@ -1,4 +1,4 @@
-## -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2019, Veritomyx, Inc.
 #

--- a/peakinvestigator/actions/base.py
+++ b/peakinvestigator/actions/base.py
@@ -1,4 +1,4 @@
-## -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2016, Veritomyx, Inc.
 #
@@ -22,28 +22,28 @@ class BaseAction():
     def __init__(self, version, username, password):
         """Constructor
         """
-        
+
         self.version = version
         self.username = username
         self.password = password
-        
-    
+
+
     @abstractmethod
     def build_query(self):
         """Builds the query for the API call.
-        
+
         Returns a dictionary containing all the info necessary.
         """
-        
+
         return dict(Version=self.version, User=self.username, Code=self.password)
-    
-    
+
+
     def process_response(self, response):
-        """Process the response (a string) of an API call. If the response 
+        """Process the response (a string) of an API call. If the response
         appears to be HTML, an exception is raised.
 
         """
-        
+
         if '<' in response:
             raise Exception("Given response appears to be HTML, not JSON.")
 
@@ -57,15 +57,15 @@ class BaseAction():
 
         if not hasattr(self, "_data"):
             raise Exception("API response is missing. Has execute() been called ?")
-        
-    
+
+
     @property
     def error(self):
-        """Returns the error message, or raises an exception if there wasn't 
+        """Returns the error message, or raises an exception if there wasn't
         an error.
-        
+
         """
-        
+
         self.precheck()
         if "Error" not in self._data:
             return None

--- a/peakinvestigator/actions/delete.py
+++ b/peakinvestigator/actions/delete.py
@@ -1,4 +1,4 @@
-## -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2016, Veritomyx, Inc.
 #
@@ -11,34 +11,33 @@ from datetime import datetime
 from .base import BaseAction
 
 class DeleteAction(BaseAction):
-    """This class is used to make a DELETE call to the PeakInvestigator 
+    """This class is used to make a DELETE call to the PeakInvestigator
     API. See https://peakinvestigator.veritomyx.com/api/#DELETE.
-    
+
     """
-    
+
     def __init__(self, version, username, password, job):
         """Constructor."""
-        
-        super(DeleteAction,self).__init__(version, username, password)
+
+        super(DeleteAction, self).__init__(version, username, password)
         self._job = job
 
     def build_query(self):
-        query = super(DeleteAction,self).build_query()
+        query = super(DeleteAction, self).build_query()
         query["Action"] = "DELETE"
         query["Job"] = self._job
         return query
-    
+
     @property
     def last_changed(self):
         """Date and time when job was deleted. Returns a datetime object."""
-        
-        super(DeleteAction,self).precheck()
+
+        super(DeleteAction, self).precheck()
         return datetime.strptime(self._data["Datetime"], "%Y-%m-%d %H:%M:%S")
-    
+
     @property
     def job(self):
         """Job identifier."""
-        
-        super(DeleteAction,self).precheck()
+
+        super(DeleteAction, self).precheck()
         return self._data["Job"]
-    

--- a/peakinvestigator/actions/init.py
+++ b/peakinvestigator/actions/init.py
@@ -1,4 +1,4 @@
-## -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2016, Veritomyx, Inc.
 #
@@ -10,59 +10,59 @@
 from .base import BaseAction
 
 class InitAction(BaseAction):
-    """This class is used to make an INIT call to the PeakInvestigator 
+    """This class is used to make an INIT call to the PeakInvestigator
     API. See https://peakinvestigator.veritomyx.com/api/#INIT
-    
+
     It is constructed with a Fluent API because of the number of required
     arguments.
-    
+
     """
 
 
     def __init__(self, api_version, username, password, project_id, pi_version):
         """Constructor
-        
+
         """
-        
-        super(InitAction,self).__init__(api_version, username, password)
+
+        super(InitAction, self).__init__(api_version, username, password)
         self.project_id = project_id
         self.pi_version = pi_version
-        
-        
+
+
     def with_scan_count(self, production, calibration):
         """Set the number of production and calibration scans."""
-        
+
         self.production = production
         self.calibration = calibration
         return self
-        
-    
+
+
     def with_meta_data(self, min_mass, max_mass, num_points):
-        """Set the meta data required for processing data. This also sets the 
-        desired starting and ending mass range to provided values by default, 
+        """Set the meta data required for processing data. This also sets the
+        desired starting and ending mass range to provided values by default,
         which can be further specified with with_mass_range().
-        
+
         """
-        
+
         self.min_mass = min_mass
         self.max_mass = max_mass
         self.start_mass = min_mass
         self.end_mass = max_mass
         self.num_points = num_points
         return self
-    
-    
+
+
     def with_mass_range(self, *args, **kwds):
         """Set the desired mass range for processing.
-        
+
         If arguments are provided, then the first is the starting range and the
         second is the ending range.
-        
+
         If keywords are provided, start and end are used to specify the starting
         and ending range, respectively.
 
         """
-        
+
         if len(args) == 2:
             self.start_mass = args[0]
             self.end_mass = args[1]
@@ -73,17 +73,17 @@ class InitAction(BaseAction):
             raise Exception("Inappropriate arguments or keywords.")
 
         return self
-    
-    
+
+
     def with_client_key(self, client_key):
         """Set the (optional) client key."""
-        
+
         self.client_key = client_key
         return self
-    
-    
+
+
     def build_query(self):
-        query = super(InitAction,self).build_query()
+        query = super(InitAction, self).build_query()
         query["Action"] = "INIT"
         query["ID"] = self.project_id
         query["PI_Version"] = self.pi_version
@@ -96,74 +96,73 @@ class InitAction(BaseAction):
         query["EndMass"] = self.end_mass
         if hasattr(self, "client_key"):
             query["ClientKey"] = self.client_key
-        
+
         return query
-    
-    
+
+
     @property
     def job(self):
         """The job to be used in subsequent API calls (i.e. RUN, STATUS, and DELETE)."""
-        
-        super(InitAction,self).precheck()
+
+        super(InitAction, self).precheck()
         return self._data["Job"]
-    
-    
+
+
     @property
     def id(self):
         """The (sub)project used in the INIT call."""
-        
-        super(InitAction,self).precheck()
+
+        super(InitAction, self).precheck()
         return self._data["ID"]
-    
-    
+
+
     @property
     def funds(self):
         """The funds available to the project. Returns a Decimal object."""
-        
-        super(InitAction,self).precheck()
+
+        super(InitAction, self).precheck()
         return self._data["Funds"]
 
-    
+
     @property
     def estimated_costs(self):
         """The estimated cost for the job. This returns a list of dictionaries 
         with "Instrument", "RTO", and "Cost" keys.
-        
+
         """
-        
-        super(InitAction,self).precheck()
+
+        super(InitAction, self).precheck()
         return self._data["EstimatedCost"]
-    
-    
+
+
     @property
     def instruments(self):
         """The type of instruments available for processing. Returns a set."""
-        super(InitAction,self).precheck()
-        return set([ x["Instrument"] for x in self._data["EstimatedCost"] ])
-    
-    
+        super(InitAction, self).precheck()
+        return set([ x["Instrument"] for x in self._data["EstimatedCost"]])
+
+
     @property
     def response_time_objectives(self):
-        """The RTOs available for processing. One RTO must be passed to the 
+        """The RTOs available for processing. One RTO must be passed to the
         INIT call. Returns a set.
-        
+
         """
-        
-        super(InitAction,self).precheck()
-        return set([ x["RTO"] for x in self._data["EstimatedCost"] ])
-    
-    
+
+        super(InitAction, self).precheck()
+        return set([ x["RTO"] for x in self._data["EstimatedCost"]])
+
+
     def cost(self, instrument, response_time_objective):
-        """Get the estimated job cost for a given instrument and RTO. Returns 
+        """Get the estimated job cost for a given instrument and RTO. Returns
         a Decimal object.
-        
+
         """
-        
-        super(InitAction,self).precheck()
+
+        super(InitAction, self).precheck()
         costs = [ x["Cost"] for x in self._data["EstimatedCost"] \
                     if x["Instrument"] == instrument and \
                         x["RTO"] == response_time_objective ]
-        
+
         assert len(costs) == 1
         return costs[0]
-    

--- a/peakinvestigator/actions/pi_versions.py
+++ b/peakinvestigator/actions/pi_versions.py
@@ -1,4 +1,4 @@
-## -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2016, Veritomyx, Inc.
 #
@@ -10,66 +10,66 @@
 from .base import BaseAction
 
 class PiVersionsAction(BaseAction):
-    """This class is used to make a PI_VERSIONS call to the PeakInvestigator 
+    """This class is used to make a PI_VERSIONS call to the PeakInvestigator
     API. See https://peakinvestigator.veritomyx.com/api/#PI_VERSIONS.
-    
+
     """
 
     def __init__(self, version, username, password):
         """Constructor"""
-        
-        super(PiVersionsAction,self).__init__(version, username, password)
+
+        super(PiVersionsAction, self).__init__(version, username, password)
 
 
     def build_query(self):
-        query = super(PiVersionsAction,self).build_query()
+        query = super(PiVersionsAction, self).build_query()
         query["Action"] = "PI_VERSIONS"
         return query
-    
-    
+
+
     @property
     def current_version(self):
         """Current or newest version (recommended).
-        
+
         Returns a string.
-        
+
         """
-        
-        super(PiVersionsAction,self).precheck()
+
+        super(PiVersionsAction, self).precheck()
         return self._data["Current"]
 
 
     @property
     def last_used(self):
-        """Version of PeakInvestigator most recently passed to an INIT 
+        """Version of PeakInvestigator most recently passed to an INIT
         call (if available).
-        
+
         Returns a string.
-        
+
         """
-        
-        super(PiVersionsAction,self).precheck()
+
+        super(PiVersionsAction, self).precheck()
         return self._data["LastUsed"]
 
 
     @property
     def count(self):
         """Number of PI versions available.
-        
+
         Returns an integer.
-        
+
         """
-        
-        super(PiVersionsAction,self).precheck()
+
+        super(PiVersionsAction, self).precheck()
         return int(self._data["Count"])
 
 
     @property
     def versions(self):
-        """List of PeakInvestigator versions released including the Current 
+        """List of PeakInvestigator versions released including the Current
         version, newest to oldest [<value>,<value>,...]
-        
+
         """
-        
-        super(PiVersionsAction,self).precheck()
+
+        super(PiVersionsAction, self).precheck()
         return self._data["Versions"]

--- a/peakinvestigator/actions/run.py
+++ b/peakinvestigator/actions/run.py
@@ -1,4 +1,4 @@
-## -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2016, Veritomyx, Inc.
 #
@@ -9,63 +9,62 @@
 from .base import BaseAction
 
 class RunAction(BaseAction):
-    """This class is used to make a RUN call to the PeakInvestigator 
+    """This class is used to make a RUN call to the PeakInvestigator
     API. See https://peakinvestigator.veritomyx.com/api/#RUN.
-    
+
     It is constructed with a Fluent API because of the number of required
     arguments.
-    
+
     """
 
 
     def __init__(self, version, username, password, jobID,
                     response_time_objective):
         """Constructor
-        
+
         """
-        
-        super(RunAction,self).__init__(version, username, password)
+
+        super(RunAction, self).__init__(version, username, password)
         self._jobID = jobID
         self._response_time_objective = response_time_objective
-        
-        
+
+
     def with_files(self, *args, **kwds):
         """Specify the production and calibration data files using either
         function arguments or keywords.
-        
+
         First try keywords. If those are missing, use args[0] for production and
         args[1] for calibration, if it exists.
-        
+
         """
-        
+
         if "production" in kwds:
             self._production = kwds["production"]
         else:
             self._production = args[0]
-            
+
         if "calibration" in kwds:
             self._calibration = kwds["calibration"]
         elif len(args) == 2:
             self._calibration = args[1]
-        
+
         return self
-    
-    
+
+
     def build_query(self):
-        query = super(RunAction,self).build_query()
-        
+        query = super(RunAction, self).build_query()
+
         query["Action"] = "RUN"
         query["Job"] = self._jobID
         query["RTO"] = self._response_time_objective
         query["InputFile"] = self._production
         if hasattr(self, "_calibration"):
             query["CalibrationFile"] = self._calibration
-        
+
         return query
 
 
     @property
     def job(self):
-        super(RunAction,self).precheck()
+        super(RunAction, self).precheck()
         return self._data["Job"]
-    

--- a/peakinvestigator/actions/sandbox.py
+++ b/peakinvestigator/actions/sandbox.py
@@ -1,4 +1,4 @@
-## -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2019, Veritomyx, Inc.
 #
@@ -10,7 +10,7 @@ from .base import BaseAction
 class SandboxAction(BaseAction):
     """This class is used to make a call to the PeakInvestigator
     API via sandbox. See https://peakinvestigator.veritomyx.com/api/#SandBox.
-    
+
     """
 
     def __init__(self, action, sandboxoption=None):
@@ -27,7 +27,7 @@ class SandboxAction(BaseAction):
             query['Sandbox'] = '0'
         return query
 
-    def process_response(self,response):
+    def process_response(self, response):
         """Process response through sandbox."""
         return self.action.process_response(response)
 

--- a/peakinvestigator/actions/sftp.py
+++ b/peakinvestigator/actions/sftp.py
@@ -1,4 +1,4 @@
-## -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2016, Veritomyx, Inc.
 #
@@ -9,77 +9,75 @@
 from .base import BaseAction
 
 class SftpAction(BaseAction):
-    """This class is used to make a SFTP call to the PeakInvestigator 
+    """This class is used to make a SFTP call to the PeakInvestigator
     API. See https://peakinvestigator.veritomyx.com/api/#SFTP.
-    
+
     """
 
 
     def __init__(self, version, username, password, project_id):
         """Constructor
-        
+
         """
-        
-        super(SftpAction,self).__init__(version, username, password)
+
+        super(SftpAction, self).__init__(version, username, password)
         self.project_id = project_id
-        
-    
+
+
     def build_query(self):
-        query = super(SftpAction,self).build_query()
+        query = super(SftpAction, self).build_query()
         query["Action"] = "SFTP"
         query["ID"] = self.project_id
         return query
-    
-    
+
+
     @property
     def host(self):
         """Host to use for SFTP transfers."""
-        
-        super(SftpAction,self).precheck()
+
+        super(SftpAction, self).precheck()
         return self._data["Host"]
-    
-    
+
+
     @property
     def port(self):
         """Port to use for SFTP transfers."""
-        
-        super(SftpAction,self).precheck()
+
+        super(SftpAction, self).precheck()
         return self._data["Port"]
-    
-    
+
+
     @property
     def directory(self):
         """Directory on SFTP server to place files."""
-        
-        super(SftpAction,self).precheck()
+
+        super(SftpAction, self).precheck()
         return self._data["Directory"]
-    
-    
+
+
     @property
     def sftp_username(self):
         """Username for SFTP transfers."""
-        
-        super(SftpAction,self).precheck()
+
+        super(SftpAction, self).precheck()
         return self._data["Login"]
-    
-    
+
+
     @property
     def sftp_password(self):
         """Password for SFTP transfers."""
-        
-        super(SftpAction,self).precheck()
+
+        super(SftpAction, self).precheck()
         return self._data["Password"]
-    
-    
+
+
     @property
     def fingerprints(self):
         """List of dictionary objects representing SFTP fingerprints. Keys
-        should include Signature (e.g. DSA), 'Algorithm' (e.g. MD5), and 
+        should include Signature (e.g. DSA), 'Algorithm' (e.g. MD5), and
         'Hash'.
-        
+
         """
-        
-        super(SftpAction,self).precheck()
+
+        super(SftpAction, self).precheck()
         return self._data["Fingerprints"]
-    
-    

--- a/peakinvestigator/actions/status.py
+++ b/peakinvestigator/actions/status.py
@@ -1,4 +1,4 @@
-## -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2016-2018, Veritomyx, Inc.
 #
@@ -12,105 +12,102 @@ from datetime import datetime
 from .base import BaseAction
 
 class StatusAction(BaseAction):
-    """This class is used to make a STATUS call to the PeakInvestigator 
+    """This class is used to make a STATUS call to the PeakInvestigator
     API. See https://peakinvestigator.veritomyx.com/api/#STATUS.
-    
+
     """
 
     def __init__(self, version, username, password, job):
         """Constructor"""
-        
-        super(StatusAction,self).__init__(version, username, password)
+
+        super(StatusAction, self).__init__(version, username, password)
         self._job = job
-        
+
     def build_query(self):
-        query = super(StatusAction,self).build_query()
+        query = super(StatusAction, self).build_query()
         query["Action"] = "STATUS"
         query["Job"] = self._job
         return query
-    
+
     @property
     def job(self):
         """Job identifier."""
-        
-        super(StatusAction,self).precheck()
+
+        super(StatusAction, self).precheck()
         return self._data["Job"]
-    
+
     @property
     def status(self):
         """Current state of job: 'Preparing', 'Running', 'Done', or 'Deleted'
-        
-          * Preparing – Input or calibration files being prepared (use PREP 
+
+          * Preparing – Input or calibration files being prepared (use PREP
             call to get details)
           * Running – Job being processed
-          * Done – Job complete, job information appended to results below 
+          * Done – Job complete, job information appended to results below
           * Deleted – Job has been deleted from the server
-        
+
         """
-        
-        super(StatusAction,self).precheck()
+
+        super(StatusAction, self).precheck()
         return self._data["Status"]
-    
+
     @property
     def done(self):
-        """Convenience property indicating whether job is done. Returns a 
+        """Convenience property indicating whether job is done. Returns a
         boolean.
-        
+
         """
-        
-        super(StatusAction,self).precheck()
+
+        super(StatusAction, self).precheck()
         return self.status == "Done"
-    
+
     @property
     def last_changed(self):
         """Date and time of last status change. Returns a datetime object."""
-        
-        super(StatusAction,self).precheck()
+
+        super(StatusAction, self).precheck()
         return datetime.strptime(self._data["Datetime"], "%Y-%m-%d %H:%M:%S")
-    
+
     @property
     def cost(self):
-        """Actual cost (US$) of job charged to the Project. Returns a Decimal 
+        """Actual cost (US$) of job charged to the Project. Returns a Decimal
         object.
-        
+
         """
-        
+
         if not self.done:
             raise Exception("Job is not done.")
 
         return self._data["ActualCost"]
-    
+
     @property
     def results_file(self):
         """Path of results file available in SFTP drop."""
-        
+
         if not self.done:
             raise Exception("Job is not done.")
-        
+
         return self._data["ResultFilePaths"]['MassList']
-    
+
     @property
     def log_file(self):
         """Path of job log file available in SFTP drop."""
-        
+
         if not self.done:
             raise Exception("Job is not done.")
-        
+
         return self._data["ResultFilePaths"]['Log']
-    
+
     @property
     def num_input_scans(self):
         """Number of scans provided as input."""
-        
-        super(StatusAction,self).precheck()
+
+        super(StatusAction, self).precheck()
         return self._data["ScansInput"]
-    
+
     @property
     def num_completed_scans(self):
         """Number of scans completed and provided in results file."""
-        
-        super(StatusAction,self).precheck()
+
+        super(StatusAction, self).precheck()
         return self._data["ScansComplete"]
-    
-    
-    

--- a/peakinvestigator/actions/upload.py
+++ b/peakinvestigator/actions/upload.py
@@ -1,4 +1,4 @@
-## -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2016, Veritomyx, Inc.
 #
@@ -31,28 +31,21 @@ class UploadAction(BaseAction):
 
     @property
     def host(self):
-        """Returns host.
-
-        """
+        """Returns host."""
 
         super(UploadAction, self).precheck()
         return self._data["Host"]
 
     @property
     def port(self):
-        """Returns port.
-
-        """
+        """Returns port."""
 
         super(UploadAction, self).precheck()
         return self._data["Port"]
 
     @property
     def token(self):
-        """Returns token for upload.
-
-        """
+        """Returns token for upload."""
 
         super(UploadAction, self).precheck()
         return self._data["Token"]
-

--- a/peakinvestigator/io/__init__.py
+++ b/peakinvestigator/io/__init__.py
@@ -1,4 +1,4 @@
-## -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2019, Veritomyx, Inc.
 #

--- a/peakinvestigator/io/binary.py
+++ b/peakinvestigator/io/binary.py
@@ -1,4 +1,4 @@
-## -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2019, Veritomyx, Inc.
 #
@@ -9,7 +9,7 @@ import zlib
 import struct
 import six
 
-def save_binary(headers,data_points,handle):
+def save_binary(headers, data_points, handle):
     for item in headers:
         handle.write(six.b("# %s" % item))
     handle.write(six.b('$'))

--- a/peakinvestigator/peakinvestigator_saas.py
+++ b/peakinvestigator/peakinvestigator_saas.py
@@ -1,4 +1,4 @@
-## -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2019, Veritomyx, Inc.
 #
@@ -16,58 +16,58 @@ from peakinvestigator.progress.uploader import Uploader
 
 
 class PeakInvestigatorSaaS(object):
-    """"An object for interacting with the PeakInvestigator API. See 
-    http://veritomyx.com for more information about PeakInvestigtor and 
+    """"An object for interacting with the PeakInvestigator API. See
+    http://veritomyx.com for more information about PeakInvestigtor and
     https://peakinvestigator.veritomyx.com/api for information about the
     public API.
-    
+
     Here's an example::
-    
+
         service = PeakInvestigatorSaaS("https://peakinvestigator.veritomyx.com")
         action = PiVersionsAction("4.2", "joe", "badpw")
         response = service.execute(action)
         action.process_response(response)
-        
+
     See other documentation for more details.
-    
+
     """
 
     def __init__(self, *args, **kwds):
-        """Constructor. If the 'server' keyword is specified, that is used for 
-        the API calls. Otherwise, it will try to use the first argument. Note 
+        """Constructor. If the 'server' keyword is specified, that is used for
+        the API calls. Otherwise, it will try to use the first argument. Note
         that only the hostname without any path should be specified. If neither
         keywords or arguments are specified, it will default to
         https://peakinvestigator.veritomyx.com.
-        
+
         https:// will be pre-pended if it is missing.
-                     
+
         """
-        
+
         if "server" in kwds:
             server = kwds["server"]
         elif len(args) > 0:
             server = args[0]
         else:
             server = "https://peakinvestigator.veritomyx.com"
-            
+
         if "http" not in server:
             server = "https://" + server
-            
+
         self._server = server
-        
+
     def execute(self, action):
         """Call the API with the given action. An action should implement a
-        build_query() method that returns a dictionary containing the 
+        build_query() method that returns a dictionary containing the
         appropriate parameters for the HTTP POST request.
-        
+
         This method returns the response from the server as a string, which
         is usually processed with the same action.
-        
+
         """
-        
+
         response = requests.post(self._server + "/api/", data=action.build_query())
         return response.text
-        
+
     def upload(self, upload_action, local_file, progress_factory, num_scan=0):
         """Upload file to a SFTP server"""
         upload_action.num = num_scan
@@ -87,7 +87,7 @@ class PeakInvestigatorSaaS(object):
 
     def download(self, sftp_action, remote_file, local_file, callback=None):
         """Download a file from a SFTP server."""
-        
+
         with SSHClient() as ssh:
             ssh.set_missing_host_key_policy(WarningPolicy())
             ssh.connect(sftp_action.host, port=sftp_action.port,

--- a/peakinvestigator/progress/__init__.py
+++ b/peakinvestigator/progress/__init__.py
@@ -1,4 +1,4 @@
-## -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2019, Veritomyx, Inc.
 #

--- a/peakinvestigator/progress/logger.py
+++ b/peakinvestigator/progress/logger.py
@@ -1,4 +1,4 @@
-## -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2019, Veritomyx, Inc.
 #

--- a/peakinvestigator/progress/loggerpercentage.py
+++ b/peakinvestigator/progress/loggerpercentage.py
@@ -1,4 +1,4 @@
-## -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2019, Veritomyx, Inc.
 #
@@ -26,8 +26,8 @@ class LogProgressPercent(Progress):
     def update(self, update):
         self.count += update
         current = time.time()
-        if round(self.count/self.total*100,0) % 10 == 0:
-            sys.stdout.write('\r'+str(round(self.count/self.total*100,0))+str(' Percent'))
+        if round(self.count/self.total*100, 0) % 10 == 0:
+            sys.stdout.write('\r'+str(round(self.count/self.total*100, 0))+str(' Percent'))
         if current - self.clock > 30:
             sys.stdout.write('\n')
             self.logger.info('Finished uploading {} of {} {}.'.format(self.count, self.total, self.unit))

--- a/peakinvestigator/progress/progress.py
+++ b/peakinvestigator/progress/progress.py
@@ -1,4 +1,4 @@
-## -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2019, Veritomyx, Inc.
 #

--- a/peakinvestigator/progress/uploader.py
+++ b/peakinvestigator/progress/uploader.py
@@ -1,4 +1,4 @@
-## -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2019, Veritomyx, Inc.
 #

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-## -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2016, Veritomyx, Inc.
 #
@@ -14,4 +14,3 @@ setup(name="PeakInvestigator Python SDK", version="0.9",
         author_email="adam.tenderholt@veritomyx.com",
         url="http://veritomyx.com",
         packages=["peakinvestigator", "peakinvestigator.actions"])
-

--- a/tests/context.py
+++ b/tests/context.py
@@ -1,4 +1,4 @@
-## -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2016, Veritomyx, Inc.
 #

--- a/tests/test_binary.py
+++ b/tests/test_binary.py
@@ -1,4 +1,4 @@
-## -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2019, Veritomyx, Inc.
 #

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -1,4 +1,4 @@
-## -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2016, Veritomyx, Inc.
 #
@@ -13,34 +13,34 @@ from context import peakinvestigator
 from peakinvestigator.actions import *
 
 class TestDeleteAction(unittest.TestCase):
-    
+
     def setUp(self):
         self.action = DeleteAction("4.2","joe", "badpw", "J-1234")
-        
+
     def test_build_query(self):
         query = self.action.build_query()
-        
+
         self.assertEqual("DELETE", query["Action"])
         self.assertEqual("4.2", query["Version"])
         self.assertEqual("joe", query["User"])
         self.assertEqual("badpw", query["Code"])
         self.assertEqual("J-1234", query["Job"])
-        
+
     def test_response(self):
         response = '{"Action":"DELETE", "Job":"P-504.4256", "Datetime":"2016-02-03 18:35:06"}'
         self.action.process_response(response)
-        
+
         self.assertEqual("P-504.4256", self.action.job)
-        
+
         last_changed = self.action.last_changed
-        
+
         self.assertEqual(2016, last_changed.year)
         self.assertEqual(2, last_changed.month)
         self.assertEqual(3, last_changed.day)
         self.assertEqual(18, last_changed.hour)
         self.assertEqual(35, last_changed.minute)
         self.assertEqual(6, last_changed.second)
-        
+
 if __name__ == "__main__":
     #import sys;sys.argv = ['', 'Test.testName']
     unittest.main()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,4 +1,4 @@
-## -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2016, Veritomyx, Inc.
 #
@@ -14,10 +14,10 @@ from context import peakinvestigator
 from peakinvestigator.actions import *
 
 class TestInitAction(unittest.TestCase):
-    
+
     def setUp(self):
         self.action = InitAction("4.2", "joe", "badpw", 1234, "1.3")
-        
+
 
     def test_build_query1(self):
         """Specifies clientKey and mass range and metadata with arguments."""
@@ -25,7 +25,7 @@ class TestInitAction(unittest.TestCase):
         self.action.with_scan_count(123, 0).with_meta_data(100, 2000, 12345)
         self.action.with_mass_range(200, 1800).with_client_key("PythonTest")
         query = self.action.build_query()
-        
+
         self.assertEqual("4.2", query["Version"])
         self.assertEqual("joe", query["User"])
         self.assertEqual("badpw", query["Code"])
@@ -47,7 +47,7 @@ class TestInitAction(unittest.TestCase):
 
         self.action.with_scan_count(123, 0).with_meta_data(100, 2000, 12345)
         query = self.action.build_query()
-        
+
         self.assertEqual("4.2", query["Version"])
         self.assertEqual("joe", query["User"])
         self.assertEqual("badpw", query["Code"])
@@ -61,7 +61,7 @@ class TestInitAction(unittest.TestCase):
         self.assertEqual(2000, query["MaxMass"])
         self.assertEqual(100, query["StartMass"])
         self.assertEqual(2000, query["EndMass"])
-        
+
 
     def test_build_query3(self):
         """Specifies mass range with keywords."""
@@ -69,29 +69,29 @@ class TestInitAction(unittest.TestCase):
         self.action.with_scan_count(123, 0).with_meta_data(100, 2000, 12345)
         self.action.with_mass_range(end=1800, start=200)
         query = self.action.build_query()
-        
+
         self.assertEqual(200, query["StartMass"])
         self.assertEqual(1800, query["EndMass"])
-        
-        
+
+
     def test_response(self):
         response = '{"Action":"INIT", "Job":"V-504.1551", "ID":504, "Funds":115.01, ' + \
                         '"EstimatedCost":[{"Instrument":"TOF", "RTO":"RTO-24", "Cost":27.60}, ' + \
                         '{"Instrument":"Orbitrap", "RTO":"RTO-24", "Cost":36.22}, ' + \
                         '{"Instrument":"IonTrap", "RTO":"RTO-24", "Cost":32.59}]}'
         self.action.process_response(response)
-        
+
         self.assertEqual("V-504.1551", self.action.job)
         self.assertEqual(Decimal("115.01"), self.action.funds)
-        
+
         self.assertIn("TOF", self.action.instruments)
         self.assertIn("IonTrap", self.action.instruments)
         self.assertIn("Orbitrap", self.action.instruments)
-        
+
         self.assertIn("RTO-24", self.action.response_time_objectives)
-        
+
         self.assertEqual(Decimal("36.22"), self.action.cost("Orbitrap", "RTO-24"))
-        
+
 if __name__ == "__main__":
     #import sys;sys.argv = ['', 'Test.testName']
     unittest.main()

--- a/tests/test_pi_versions.py
+++ b/tests/test_pi_versions.py
@@ -1,4 +1,4 @@
-## -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2016, Veritomyx, Inc.
 #
@@ -20,16 +20,16 @@ class TestPiVersionsAction(unittest.TestCase):
 
     def test_build_query(self):
         query = self.action.build_query()
-        
+
         self.assertIn("Version", query)
         self.assertEqual("4.2", query["Version"])
-        
+
         self.assertIn("User", query)
         self.assertEqual("joe", query["User"])
 
         self.assertIn("Code", query)
         self.assertEqual("badpw", query["Code"])
-        
+
         self.assertIn("Action", query)
         self.assertEqual("PI_VERSIONS", query["Action"])
 
@@ -37,18 +37,18 @@ class TestPiVersionsAction(unittest.TestCase):
     def test_response(self):
         response = '{"Action":"PI_VERSIONS", "Current":"1.2", "LastUsed":"", "Count":2, "Versions":["1.2", "1.0.0"]}'
         self.action.process_response(response)
-        
+
         self.assertEqual(self.action.current_version, "1.2")
         self.assertEqual(self.action.last_used, "")
         self.assertEqual(self.action.count, 2)
         self.assertListEqual(self.action.versions, ["1.2", "1.0.0"])
         self.assertIsNone(self.action.error)
-        
+
 
     def test_error(self):
         response = '{"Action":"PI_VERSIONS", "Error":3, "Message":"Invalid username or password - can not validate"}'
         self.action.process_response(response)
-        
+
         self.assertEqual(self.action.error, "Invalid username or password - can not validate")
         
 if __name__ == "__main__":

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,4 +1,4 @@
-## -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2016, Veritomyx, Inc.
 #
@@ -13,16 +13,16 @@ from context import peakinvestigator
 from peakinvestigator.actions import *
 
 class TestRunAction(unittest.TestCase):
-    
+
     def setUp(self):
         self.action = RunAction("4.2", "joe", "badpw", "J-1234", "RTO-24")
-        
+
     def test_build_query1(self):
         """Test full case"""
-        
+
         self.action.with_files("production.data.tar", "calibration.data.tar")
         query = self.action.build_query()
-        
+
         self.assertEqual("RUN", query["Action"])
         self.assertEqual("4.2", query["Version"])
         self.assertEqual("joe", query["User"])
@@ -31,41 +31,41 @@ class TestRunAction(unittest.TestCase):
         self.assertEqual("RTO-24", query["RTO"])
         self.assertEqual("production.data.tar", query["InputFile"])
         self.assertEqual("calibration.data.tar", query["CalibrationFile"])
-        
+
     def test_build_query2(self):
         """Test without calibration"""
-        
+
         self.action.with_files("production.data.tar")
         query = self.action.build_query()
-        
+
         self.assertEqual("production.data.tar", query["InputFile"])
         self.assertNotIn("CalibrationFile", query)
-        
+
     def test_build_query3(self):
         """ Test using keywords without calibration"""
-        
+
         self.action.with_files(production="production.data.tar")
         query = self.action.build_query()
-        
+
         self.assertEqual("production.data.tar", query["InputFile"])
         self.assertNotIn("CalibrationFile", query)
-        
+
     def test_build_query4(self):
         """ Test using keywords with calibration"""
-        
+
         self.action.with_files(calibration="calibration.data.tar",
                                 production="production.data.tar")
         query = self.action.build_query()
-        
+
         self.assertEqual("production.data.tar", query["InputFile"])
         self.assertEqual("calibration.data.tar", query["CalibrationFile"])
-        
+
     def test_response(self):
         response = '{"Action":"RUN", "Job":"P-504.1463"}'
         self.action.process_response(response)
-        
+
         self.assertEqual("P-504.1463", self.action.job)
-        
+
 if __name__ == "__main__":
     #import sys;sys.argv = ['', 'Test.testName']
     unittest.main()

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,4 +1,4 @@
-## -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2019, Veritomyx, Inc.
 #
@@ -42,16 +42,16 @@ class TestSandboxAction(unittest.TestCase):
             }]
         }
         """
-        self.assertEqual(actionInit.build_query(),dict(Version="5.1", User="user",Code="password",Action="INIT",ID="100",PI_Version="1.2",
-                                                            ScanCount=5,CalibrationCount=0,MaxPoints=12345,MinMass=50,MaxMass=100,StartMass=50,EndMass=100,ClientKey="SDKTest",Sandbox="0"))
+        self.assertEqual(actionInit.build_query(), dict(Version="5.1", User="user", Code="password", Action="INIT", ID="100", PI_Version="1.2",
+                                                            ScanCount=5, CalibrationCount=0, MaxPoints=12345, MinMass=50, MaxMass=100, StartMass=50, EndMass=100, ClientKey="SDKTest", Sandbox="0"))
         actionInit.process_response(response)
-        self.assertEqual("V-504.1551",actionInit.job)
-        self.assertEqual(504,actionInit.id)
-        self.assertEqual(Decimal("115.01"),actionInit.funds)
+        self.assertEqual("V-504.1551", actionInit.job)
+        self.assertEqual(504, actionInit.id)
+        self.assertEqual(Decimal("115.01"), actionInit.funds)
         costs = actionInit.estimated_costs
-        self.assertEqual(Decimal("27.60"),costs[0]['Cost'])
-        self.assertEqual(Decimal("36.22"),costs[1]['Cost'])
-        self.assertEqual(Decimal("32.59"),costs[2]['Cost'])
+        self.assertEqual(Decimal("27.60"), costs[0]['Cost'])
+        self.assertEqual(Decimal("36.22"), costs[1]['Cost'])
+        self.assertEqual(Decimal("32.59"), costs[2]['Cost'])
 
     def test_responseRun(self):
         """Test Sandbox using Run Action"""
@@ -63,14 +63,14 @@ class TestSandboxAction(unittest.TestCase):
             "Job": "P-504.1463"
         }
         """
-        self.assertEqual(actionRun.build_query(),dict(Version="5.1", User="user", Code="password", Action="RUN", Job="100", RTO="RTO-24",
+        self.assertEqual(actionRun.build_query(), dict(Version="5.1", User="user", Code="password", Action="RUN", Job="100", RTO="RTO-24",
                                                            InputFile="production.data.tar", CalibrationFile="calibration.data.tar", Sandbox="0"))
         actionRun.process_response(response)
         self.assertEqual("P-504.1463", actionRun.job)
 
     def test_responseStatus(self):
         """Test Sandbox using Status Action"""
-        actionStatus = SandboxAction(StatusAction("5.1","user","password","100"))
+        actionStatus = SandboxAction(StatusAction("5.1", "user", "password", "100"))
         response1 = """
         {
             "Action":"STATUS",
@@ -92,7 +92,7 @@ class TestSandboxAction(unittest.TestCase):
             "ResultFilePaths":{
                 "Log":"/files/P-504.5148/P-504.5148.log.txt",
                 "MassList":"/files/P-504.5148/P-504.5148.mass_list.tar"
-            } 
+            }
         }
         """
         response3 = """
@@ -103,29 +103,29 @@ class TestSandboxAction(unittest.TestCase):
             "Datetime":"2016-02-03 18:36:05"
         }
         """
-        self.assertEqual(actionStatus.build_query(),dict(Version="5.1", User="user", Code="password", Action="STATUS",Job="100", Sandbox="0"))
+        self.assertEqual(actionStatus.build_query(), dict(Version="5.1", User="user", Code="password", Action="STATUS", Job="100", Sandbox="0"))
         actionStatus.process_response(response1)
-        self.assertEqual("P-504.5148",actionStatus.job)
-        self.assertEqual("Running",actionStatus.status)
-        self.assertEqual(False,actionStatus.done)
-        self.assertEqual(datetime.datetime(2016, 2, 3, 18, 25, 9),actionStatus.last_changed)
+        self.assertEqual("P-504.5148", actionStatus.job)
+        self.assertEqual("Running", actionStatus.status)
+        self.assertEqual(False, actionStatus.done)
+        self.assertEqual(datetime.datetime(2016, 2, 3, 18, 25, 9), actionStatus.last_changed)
 
         actionStatus.process_response(response2)
-        self.assertEqual("P-504.5148",actionStatus.job)
-        self.assertEqual("Done",actionStatus.status)
-        self.assertEqual(True,actionStatus.done)
-        self.assertEqual(datetime.datetime(2016, 2, 3, 18, 31, 5),actionStatus.last_changed)
-        self.assertEqual(Decimal("0.36"),actionStatus.cost)
-        self.assertEqual("/files/P-504.5148/P-504.5148.mass_list.tar",actionStatus.results_file)
-        self.assertEqual("/files/P-504.5148/P-504.5148.log.txt",actionStatus.log_file)
-        self.assertEqual(3,actionStatus.num_input_scans)
-        self.assertEqual(3,actionStatus.num_completed_scans)
+        self.assertEqual("P-504.5148", actionStatus.job)
+        self.assertEqual("Done", actionStatus.status)
+        self.assertEqual(True, actionStatus.done)
+        self.assertEqual(datetime.datetime(2016, 2, 3, 18, 31, 5), actionStatus.last_changed)
+        self.assertEqual(Decimal("0.36"), actionStatus.cost)
+        self.assertEqual("/files/P-504.5148/P-504.5148.mass_list.tar", actionStatus.results_file)
+        self.assertEqual("/files/P-504.5148/P-504.5148.log.txt", actionStatus.log_file)
+        self.assertEqual(3, actionStatus.num_input_scans)
+        self.assertEqual(3, actionStatus.num_completed_scans)
 
         actionStatus.process_response(response3)
-        self.assertEqual("P-504.1463",actionStatus.job)
-        self.assertEqual("Deleted",actionStatus.status)
-        self.assertEqual(False,actionStatus.done)
-        self.assertEqual(datetime.datetime(2016, 2, 3, 18, 36, 5),actionStatus.last_changed)
+        self.assertEqual("P-504.1463", actionStatus.job)
+        self.assertEqual("Deleted", actionStatus.status)
+        self.assertEqual(False, actionStatus.done)
+        self.assertEqual(datetime.datetime(2016, 2, 3, 18, 36, 5), actionStatus.last_changed)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -1,4 +1,4 @@
-## -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2016, Veritomyx, Inc.
 #
@@ -13,21 +13,21 @@ from context import peakinvestigator
 from peakinvestigator.actions import *
 
 class TestSftpAction(unittest.TestCase):
-    
+
     def setUp(self):
         self.action = SftpAction("4.2", "joe", "badpw", 1234)
-    
-    
+
+
     def test_build_query(self):
         query = self.action.build_query()
-        
+
         self.assertEqual("SFTP", query["Action"])
         self.assertEqual("4.2", query["Version"])
         self.assertEqual("joe", query["User"])
         self.assertEqual("badpw", query["Code"])
         self.assertEqual(1234, query["ID"])
-        
-    
+
+
     def test_response(self):
         response = '{"Action":"SFTP", "Host":"peakinvestigator.veritomyx.com", ' + \
                         '"Port":22022, "Directory":"/files", "Login":"Vt504", ' + \
@@ -39,14 +39,14 @@ class TestSftpAction(unittest.TestCase):
                         '{"Signature":"ECDSA","Algorithm":"SHA256","Hash":"d2HXgeUSmWN+gq+9V7Wad5xWaCxk+mh45F81K951MCU"}, ' + \
                         '{"Signature":"RSA","Algorithm":"MD5","Hash":"d2:be:b8:2e:3c:be:84:e4:a3:0a:c8:42:5c:6b:39:4e"}, ' + \
                         '{"Signature":"RSA","Algorithm":"SHA256","Hash":"QBsg8ejj4gZun4AWd4WBTJw89ftcLR9x/dZoG223srg"}]}'
-        self.action.process_response(response) 
-        
+        self.action.process_response(response)
+
         self.assertEqual("peakinvestigator.veritomyx.com", self.action.host)
         self.assertEqual(22022, self.action.port)
         self.assertEqual("/files", self.action.directory)
         self.assertEqual("Vt504", self.action.sftp_username)
         self.assertEqual("0UtnWMvzoi2jF4BQ", self.action.sftp_password)
-        
+
 if __name__ == "__main__":
     #import sys;sys.argv = ['', 'Test.testName']
     unittest.main()

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,4 +1,4 @@
-## -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2016-2018, Veritomyx, Inc.
 #
@@ -36,43 +36,43 @@ RESPONSE_4 = '{"Action":"STATUS", "Job":"P-504.1463", "Status":"Deleted", "Datet
 
 
 class TestStatusAction(unittest.TestCase):
-    
+
     def setUp(self):
         self.action = StatusAction("4.2", "joe", "badpw", "J-1234")
-        
+
     def test_build_query(self):
         query = self.action.build_query()
-        
+
         self.assertEqual("STATUS", query["Action"])
         self.assertEqual("4.2", query["Version"])
         self.assertEqual("joe", query["User"])
         self.assertEqual("badpw", query["Code"])
         self.assertEqual("J-1234", query["Job"])
-        
+
     def test_response1(self):
         self.action.process_response(RESPONSE_1)
-    
+
         self.assertEqual("P-504.5148", self.action.job)
         self.assertEqual("Preparing", self.action.status)
         self.assertFalse(self.action.done)
-        
+
         last_changed = self.action.last_changed
-        
+
         self.assertEqual(2016, last_changed.year)
         self.assertEqual(2, last_changed.month)
         self.assertEqual(3, last_changed.day)
         self.assertEqual(18, last_changed.hour)
         self.assertEqual(18, last_changed.minute)
         self.assertEqual(12, last_changed.second)
-        
+
     def test_response2(self):
         self.action.process_response(RESPONSE_2)
         self.assertFalse(self.action.done)
         self.assertEqual("Running", self.action.status)
-        
+
     def test_response3(self):
         self.action.process_response(RESPONSE_3)
-        
+
         self.assertTrue(self.action.done)
         self.assertEqual("Done", self.action.status)
         self.assertEqual(3, self.action.num_input_scans)
@@ -82,10 +82,10 @@ class TestStatusAction(unittest.TestCase):
                             self.action.log_file)
         self.assertEqual("/files/P-504.5148/P-504.5148.mass_list.tar",
                             self.action.results_file)
-        
+
     def test_response4(self):
         self.action.process_response(RESPONSE_4)
-        
+
         self.assertFalse(self.action.done)
         self.assertEqual("Deleted", self.action.status)
 

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,4 +1,4 @@
-## -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2016, Veritomyx, Inc.
 #
@@ -30,7 +30,6 @@ class TestUploadAction(unittest.TestCase):
     def test_response(self):
         response = '{"Action":"UPLOAD", "Host":"peakinvestigator.veritomyx.com", "Port":"22022", "Token": "640f89508eba4d9e8b5951fb083e97ac"}'
         self.action.process_response(response)
-
         self.assertEqual("peakinvestigator.veritomyx.com", self.action.host)
         self.assertEqual("22022", self.action.port)
         self.assertEqual("640f89508eba4d9e8b5951fb083e97ac", self.action.token)


### PR DESCRIPTION
Removed multiple errors such as below.

peakinvestigator/__init__.py:1:1: E266 too many leading '#' for block comment
peakinvestigator/__init__.py:9:56: W292 no newline at end of file
peakinvestigator/peakinvestigator_saas.py:1:1: E266 too many leading '#' for block comment
peakinvestigator/peakinvestigator_saas.py:19:65: W291 trailing whitespace
peakinvestigator/peakinvestigator_saas.py:20:72: W291 trailing whitespace
peakinvestigator/peakinvestigator_saas.py:23:1: W293 blank line contains whitespace
peakinvestigator/peakinvestigator_saas.py:25:1: W293 blank line contains whitespace
peakinvestigator/peakinvestigator_saas.py:30:1: W293 blank line contains whitespace

Errors below are either inherent to code structure, or something I wanted to check before correction.

peakinvestigator/__init__.py:9:1: F401 '.peakinvestigator_saas.PeakInvestigatorSaaS' imported but unused
peakinvestigator/peakinvestigator_saas.py:26:80: E501 line too long (80 > 79 characters)